### PR TITLE
fix(java): Avoid rounding through implict cast to uint16_t

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -37,7 +37,7 @@ static class VersionInfo
         return int.Parse(text[(startOfMarker + marker.Length)..endOfMarker].Trim());
     }
 
-    static readonly Version FileVersionBase = new Version(3, 2, 0, 0);
+    static readonly Version FileVersionBase = new Version(3, 3, 0, 0);
 
     #endregion
 

--- a/lib/dotnet/Directory.Build.props
+++ b/lib/dotnet/Directory.Build.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<Version Condition=" '$(Version)' == '' ">3.2.135</Version>
+		<Version Condition=" '$(Version)' == '' ">3.3.135</Version>
 		<AssemblyVersion Condition=" '$(AssemblyVersion)' == '' ">$(Version).0</AssemblyVersion>
 		<FileVersion Condition=" '$(FileVersion)' == '' ">$(AssemblyVersion)</FileVersion>
 		<NeutralLanguage>en</NeutralLanguage>

--- a/lib/java/build.gradle.kts
+++ b/lib/java/build.gradle.kts
@@ -20,7 +20,7 @@ var libAuthorId = ""
 var libAuthorName = ""
 var libOrgUrl = ""
 var libCompany = ""
-var libVersion = "3.2.135"
+var libVersion = "3.3.135"
 var libProjectUrl = ""
 var libGitUrlHttp = ""
 var libGitUrlGit = ""
@@ -70,6 +70,8 @@ loadSetting("ALPHASKIA_ISSUES_URL", "alphaskiaIssuesUrl") { libIssuesUrl = it }
 group = libGroup
 version = libVersion
 
+internal fun Project.findOptionalProperty(propertyName: String) = findProperty(propertyName)?.toString()
+
 subprojects {
     apply<MavenPublishPlugin>()
     apply(plugin = "maven-publish")
@@ -111,6 +113,15 @@ subprojects {
 
     afterEvaluate {
         configure<MavenPublishBaseExtension> {
+            val inMemoryKeyFile = project.findOptionalProperty("signingInMemoryKeyFile")
+            if (inMemoryKeyFile != null) {
+                val inMemoryKeyId = project.findOptionalProperty("signingInMemoryKeyId")
+                val inMemoryKeyPassword = project.findOptionalProperty("signingInMemoryKeyPassword").orEmpty()
+                val signing = project.extensions.getByType(SigningExtension::class.java)
+                val inMemoryKey = File(inMemoryKeyFile).readText()
+                signing.useInMemoryPgpKeys(inMemoryKeyId, inMemoryKey, inMemoryKeyPassword)
+            }
+
             pom {
                 val artifactId = tasks.withType<Jar>().firstOrNull()?.archiveBaseName?.get()
                     ?: throw Exception("Could not find artifact id for maven POM")

--- a/lib/java/jni/src/AlphaSkiaTextMetrics.cpp
+++ b/lib/java/jni/src/AlphaSkiaTextMetrics.cpp
@@ -9,7 +9,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_width(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_width(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -18,7 +18,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_actual_bounding_box_left(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_actual_bounding_box_left(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -27,7 +27,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_actual_bounding_box_right(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_actual_bounding_box_right(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -36,7 +36,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_font_bounding_box_ascent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_font_bounding_box_ascent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -45,7 +45,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_font_bounding_box_descent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_font_bounding_box_descent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -54,7 +54,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_actual_bounding_box_ascent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_actual_bounding_box_ascent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -63,7 +63,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_actual_bounding_box_descent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_actual_bounding_box_descent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -72,7 +72,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_em_height_ascent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_em_height_ascent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -81,7 +81,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_em_height_descent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_em_height_descent(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -90,7 +90,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_hanging_baseline(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_hanging_baseline(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -99,7 +99,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_alphabetic_baseline(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_alphabetic_baseline(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 
@@ -108,7 +108,7 @@ extern "C"
         jlong handle = get_handle(env, instance);
         CHECK_HANDLE_RETURN(handle, static_cast<jfloat>(0))
 
-        uint16_t value = alphaskia_text_metrics_get_ideographic_baseline(reinterpret_cast<alphaskia_text_metrics_t>(handle));
+        float value = alphaskia_text_metrics_get_ideographic_baseline(reinterpret_cast<alphaskia_text_metrics_t>(handle));
         return static_cast<jfloat>(value);
     }
 

--- a/lib/node/alphaskia-linux/package.json
+++ b/lib/node/alphaskia-linux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderline/alphaskia-linux",
-  "version": "3.2.135",
+  "version": "3.3.135",
   "description": "The node addon for alphaSkia enabling it to run on Linux",
   "engines": {
     "node": ">=18.0.0"

--- a/lib/node/alphaskia-macos/package.json
+++ b/lib/node/alphaskia-macos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderline/alphaskia-macos",
-  "version": "3.2.135",
+  "version": "3.3.135",
   "description": "The node addon for alphaSkia enabling it to run on MacOS",
   "engines": {
     "node": ">=18.0.0"

--- a/lib/node/alphaskia-windows/package.json
+++ b/lib/node/alphaskia-windows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderline/alphaskia-windows",
-  "version": "3.2.135",
+  "version": "3.3.135",
   "description": "The node addon for alphaSkia enabling it to run on Windows",
   "engines": {
     "node": ">=18.0.0"

--- a/lib/node/alphaskia/package.json
+++ b/lib/node/alphaskia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coderline/alphaskia",
-  "version": "3.2.135",
+  "version": "3.3.135",
   "description": "A Skia based rendering backend for alphaTab.",
   "module": "./dist/alphaskia.mjs",
   "typings": "./dist/alphaskia.d.ts",

--- a/test/java/build.gradle.kts
+++ b/test/java/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // do not inline (updated dynamically via Nuke)
-var libVersion = "3.2.135"
+var libVersion = "3.3.135"
 
 group = "alphaTab.alphaSkia"
 version = libVersion

--- a/test/node/package.json
+++ b/test/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaskiatest",
-  "version": "3.2.135",
+  "version": "3.3.135",
   "private": true,
   "scripts": {
     "start": "tsx index.ts"


### PR DESCRIPTION
Another round (locally tested this time) to ensure we have no rounding on the java version. 